### PR TITLE
Improve Python structure and add utilities

### DIFF
--- a/curriculo_docx.py
+++ b/curriculo_docx.py
@@ -1,310 +1,154 @@
-from docx import Document
-from docx.shared import Pt, RGBColor
-from docx.oxml.parser import OxmlElement
-from docx.oxml.ns import qn
-from docx.enum.text import WD_PARAGRAPH_ALIGNMENT, WD_BREAK
-from docx.enum.table import WD_TABLE_ALIGNMENT
-from docx.oxml import parse_xml
-from docx.shared import Inches
-import os
-import json
-import sys
-import glob
+"""Command line tool to generate DOCX resumes from JSON files."""
+from __future__ import annotations
+
 import argparse
+import json
+import os
+import sys
+
 from templates import TemplateManager
+from utils import (
+    get_available_languages,
+    get_field,
+    get_jobs,
+    get_section_content,
+    get_section_list,
+    get_section_title,
+)
 
-# Configurar os argumentos de linha de comando
-parser = argparse.ArgumentParser(description='Gerar currículo em formato DOCX.')
-parser.add_argument('language', nargs='?', help='Código do idioma (ex: pt, en, es)')
-parser.add_argument('--template', '-t', help='Nome do template a ser usado', default='docx')
-parser.add_argument('--json-file', help='Caminho para um arquivo JSON personalizado', default=None)
-args = parser.parse_args()
 
-# Função para listar idiomas disponíveis
-def get_available_languages():
-    # Procurar todos os arquivos JSON que seguem o padrão curriculo_XX.json
-    json_files = glob.glob('curriculo_*.json')
-    languages = {}
-    
-    for file in json_files:
-        # Extrair o código do idioma do nome do arquivo (curriculo_XX.json -> XX)
-        lang_code = file.replace('curriculo_', '').replace('.json', '')
-        
-        # Carregar o arquivo para obter o nome do idioma na própria língua
-        try:
-            with open(file, 'r', encoding='utf-8') as f:
-                data = json.load(f)
-                
-                # Verificar se o arquivo tem a estrutura esperada
-                if 'languageName' in data:
-                    lang_name = data['languageName']
-                else:
-                    # Fallback para casos onde o nome do idioma não está definido
-                    lang_name = lang_code.upper()
-                
-                languages[lang_code] = {
-                    'name': lang_name,
-                    'file': file
-                }
-        except:
-            # Se houver erro ao carregar ou analisar, pular este arquivo
-            pass
-    
-    return languages
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Gerar currículo em formato DOCX.")
+    parser.add_argument("language", nargs="?", help="Código do idioma (ex: pt, en, es)")
+    parser.add_argument("--template", "-t", default="docx", help="Nome do template a ser usado")
+    parser.add_argument("--json-file", help="Caminho para um arquivo JSON personalizado", default=None)
+    return parser.parse_args()
 
-# Determinar o idioma a ser usado
-available_languages = get_available_languages()
 
-# Default para português se disponível, caso contrário usa o primeiro idioma disponível
-default_lang = 'pt' if 'pt' in available_languages else list(available_languages.keys())[0] if available_languages else None
+def load_resume_data(language: str | None, json_file: str | None) -> tuple[dict, str]:
+    available_languages = get_available_languages()
+    default_lang = "pt" if "pt" in available_languages else next(iter(available_languages), None)
+    selected_lang = default_lang
+    if language and language.lower() in available_languages:
+        selected_lang = language.lower()
 
-# Verificar qual idioma usar com base nos argumentos de linha de comando
-selected_lang = default_lang
-if args.language:
-    lang_arg = args.language.lower()
-    if lang_arg in available_languages:
-        selected_lang = lang_arg
-
-# Se não houver idiomas disponíveis, terminar o programa
-if not selected_lang and not args.json_file:
-    print("Erro: Não foram encontrados arquivos de idioma válidos.")
-    sys.exit(1)
-
-# Carregar o arquivo JSON
-if args.json_file:
-    print(f"Usando arquivo JSON personalizado: {args.json_file}")
-    # Usar o arquivo JSON personalizado
-    try:
-        with open(args.json_file, 'r', encoding='utf-8') as file:
-            data = json.load(file)
-    except Exception as e:
-        print(f"Erro ao carregar arquivo JSON personalizado: {str(e)}")
+    if not selected_lang and not json_file:
+        print("Erro: Não foram encontrados arquivos de idioma válidos.")
         sys.exit(1)
-else:
-    # Carregar o arquivo JSON do idioma selecionado
-    json_file = available_languages[selected_lang]['file']
-    with open(json_file, 'r', encoding='utf-8') as file:
-        data = json.load(file)
 
-# Carregar o template
-template_manager = TemplateManager()
-template_name = args.template
+    if json_file:
+        with open(json_file, "r", encoding="utf-8") as file:
+            data = json.load(file)
+        return data, selected_lang or "pt"
 
-try:
-    template = template_manager.get_template(template_name)
-    print(f"Usando template: {template_name}")
-except ValueError as e:
-    print(f"Erro ao carregar template: {str(e)}")
-    print(f"Templates disponíveis: {', '.join(template_manager.list_templates())}")
-    print("Usando o template padrão 'docx'.")
-    template = template_manager.get_template('docx')
+    json_file_path = available_languages[selected_lang]["file"]
+    with open(json_file_path, "r", encoding="utf-8") as file:
+        return json.load(file), selected_lang
 
-# Novo documento
-doc = template.create_document()
 
-# Função genérica para obter valores do JSON de maneira padronizada
-def get_field(data, primary_key, fallback_key=None, additional_fallbacks=None):
-    if primary_key in data:
-        return data[primary_key]
-    elif fallback_key and fallback_key in data:
-        return data[fallback_key]
-    
-    # Verificar chaves adicionais específicas para alguns campos
-    if additional_fallbacks:
-        for key in additional_fallbacks:
-            if key in data:
-                return data[key]
-    
-    return None
+def build_document(data: dict, template_name: str, selected_lang: str) -> str:
+    template_manager = TemplateManager()
+    try:
+        template = template_manager.get_template(template_name)
+    except ValueError:
+        print(f"Template '{template_name}' não encontrado. Usando padrão 'docx'.")
+        template = template_manager.get_template("docx")
 
-# Função genérica para obter título de seção
-def get_section_title(section_data, title_keys=['titulo', 'title', 'titre', 'titel']):
-    for key in title_keys:
-        if key in section_data:
-            return section_data[key]
-    return "N/A"  # Fallback
+    doc = template.create_document()
 
-# Função genérica para obter conteúdo de seção
-def get_section_content(section_data, content_keys=['conteudo', 'content', 'contenido', 'inhalt']):
-    for key in content_keys:
-        if key in section_data:
-            return section_data[key]
-    return ""  # Fallback
+    nome = get_field(data, "nome", "name", ["nombre"])
+    email = data.get("email", "")
+    telefone = get_field(data, "telefone", "phone")
+    linkedin = data.get("linkedin", "")
 
-# Função genérica para obter lista de itens
-def get_section_list(section_data, list_keys=['lista', 'list', 'liste', 'lista']):
-    for key in list_keys:
-        if key in section_data:
-            return section_data[key]
-    return []  # Fallback
+    secoes_key = next((k for k in ["secoes", "sections", "secciones", "sektionen"] if k in data), None)
+    if not secoes_key:
+        raise ValueError("Formato de arquivo JSON inválido. A chave de seções não foi encontrada.")
+    secoes = data[secoes_key]
 
-# Função genérica para obter lista de empregos/experiências
-def get_jobs(section_data, jobs_keys=['empregos', 'jobs', 'empleos', 'emplois']):
-    for key in jobs_keys:
-        if key in section_data:
-            return section_data[key]
-    return []  # Fallback
+    template.add_title(doc, nome, email, telefone, linkedin)
 
-# Extrair dados básicos do JSON
-# Estrutura padronizada para todas as línguas
-nome = get_field(data, 'nome', 'name', ['nombre'])
-email = data['email']
-telefone = get_field(data, 'telefone', 'phone')
-linkedin = data['linkedin']
+    resume_section = next((secoes[k] for k in [
+        "resumoProfissional",
+        "professionalSummary",
+        "resumenProfesional",
+        "resumentProfessionnel",
+    ] if k in secoes), None)
+    if resume_section:
+        template.add_section_title(doc, get_section_title(resume_section))
+        doc.add_paragraph(get_section_content(resume_section))
 
-# Determinar qual é a chave principal para seções
-secoes_key = None
-for key in ['secoes', 'sections', 'secciones', 'sektionen']:
-    if key in data:
-        secoes_key = key
-        break
+    experience_section = next((secoes[k] for k in [
+        "experienciaProfissional",
+        "workExperience",
+        "experienciaLaboral",
+        "experienceProfessionnelle",
+    ] if k in secoes), None)
+    if experience_section:
+        template.add_section_title(doc, get_section_title(experience_section))
+        for job in get_jobs(experience_section):
+            position = get_field(job, "cargo", "position")
+            if position:
+                doc.add_paragraph(position, style="List Bullet")
+            period = get_field(job, "periodo", "period")
+            if period:
+                doc.add_paragraph(period)
+            description_items = next((job[k] for k in ["descricao", "description", "descripcion"] if k in job), [])
+            descricao = "".join(f"- {item}\n" for item in description_items)
+            if descricao:
+                doc.add_paragraph(descricao)
 
-# Se não encontrarmos a chave das seções, não podemos continuar
-if not secoes_key:
-    print("Erro: Formato de arquivo JSON inválido. A chave de seções não foi encontrada.")
-    sys.exit(1)
+    template.add_page_break(doc)
+    skills_section = next((secoes[k] for k in [
+        "habilidadesTecnicas",
+        "technicalSkills",
+        "habilidadesTecnicas",
+        "competencesTechniques",
+    ] if k in secoes), None)
+    if skills_section:
+        template.add_section_title(doc, get_section_title(skills_section))
+        skills = next((skills_section[k] for k in ["habilidades", "skills", "habilidades", "competences"] if k in skills_section), [])
+        for skill in skills:
+            skill_name = get_field(skill, "nome", "name")
+            skill_level = get_field(skill, "nivel", "level")
+            if skill_name and skill_level:
+                template.add_skill_bar(doc, skill_name, skill_level)
 
-secoes = data[secoes_key]
+    certifications_section = next((secoes[k] for k in ["certificacoes", "certifications", "certificaciones", "certifications"] if k in secoes), None)
+    if certifications_section:
+        template.add_section_title(doc, get_section_title(certifications_section))
+        for cert in get_section_list(certifications_section):
+            p = doc.add_paragraph()
+            p.add_run("🏅 ").bold = True
+            p.add_run(cert)
 
-# Montando o currículo visual
-template.add_title(doc, nome, email, telefone, linkedin)
+    education_section = next((secoes[k] for k in ["educacao", "education", "educacion", "education"] if k in secoes), None)
+    if education_section:
+        template.add_section_title(doc, get_section_title(education_section))
+        for degree in next((education_section[k] for k in ["formacao", "degrees", "formacion", "diplomes"] if k in education_section), []):
+            doc.add_paragraph(degree)
 
-# Resumo Profissional - procurar por várias possíveis chaves
-resume_section = None
-for key in ['resumoProfissional', 'professionalSummary', 'resumenProfesional', 'resumentProfessionnel']:
-    if key in secoes:
-        resume_section = secoes[key]
-        break
+    in_progress_section = next((secoes[k] for k in ["emAndamento", "inProgress", "enProgreso", "enCours"] if k in secoes), None)
+    if in_progress_section:
+        template.add_section_title(doc, get_section_title(in_progress_section))
+        for course in next((in_progress_section[k] for k in ["cursos", "courses", "cursos", "cours"] if k in in_progress_section), []):
+            doc.add_paragraph(course)
 
-if resume_section:
-    template.add_section_title(doc, get_section_title(resume_section))
-    doc.add_paragraph(get_section_content(resume_section))
+    output_path = get_field(data, "nomeArquivoSaida", "outputFileName")
+    if not output_path:
+        output_name = nome.replace(" ", "_") if nome else "Curriculo"
+        output_path = f"{output_name}_{selected_lang}.docx"
 
-# Experiência Profissional - procurar por várias possíveis chaves
-experience_section = None
-for key in ['experienciaProfissional', 'workExperience', 'experienciaLaboral', 'experienceProfessionnelle']:
-    if key in secoes:
-        experience_section = secoes[key]
-        break
+    doc.save(output_path)
+    return output_path
 
-if experience_section:
-    template.add_section_title(doc, get_section_title(experience_section))
-    
-    # Obter lista de empregos
-    jobs = get_jobs(experience_section)
-    
-    # Adicionar empregos
-    for job in jobs:
-        position = get_field(job, 'cargo', 'position')
-        if position:
-            doc.add_paragraph(position, style='List Bullet')
-        
-        period = get_field(job, 'periodo', 'period')
-        if period:
-            doc.add_paragraph(period)
-        
-        # Obter descrição - procurar por várias possíveis chaves
-        description_items = []
-        for key in ['descricao', 'description', 'descripcion']:
-            if key in job:
-                description_items = job[key]
-                break
-        
-        # Montar descrição
-        descricao = ""
-        for item in description_items:
-            descricao += f"- {item}\n"
-        doc.add_paragraph(descricao)
 
-# Habilidades Técnicas - procurar por várias possíveis chaves
-template.add_page_break(doc)
-skills_section = None
-for key in ['habilidadesTecnicas', 'technicalSkills', 'habilidadesTecnicas', 'competencesTechniques']:
-    if key in secoes:
-        skills_section = secoes[key]
-        break
+def main() -> None:
+    args = parse_args()
+    data, lang = load_resume_data(args.language, args.json_file)
+    output = build_document(data, args.template, lang)
+    print(f"Arquivo salvo como: {output}")
 
-if skills_section:
-    template.add_section_title(doc, get_section_title(skills_section))
-    
-    # Obter lista de habilidades
-    skills = []
-    for key in ['habilidades', 'skills', 'habilidades', 'competences']:
-        if key in skills_section:
-            skills = skills_section[key]
-            break
-    
-    for skill in skills:
-        skill_name = get_field(skill, 'nome', 'name')
-        skill_level = get_field(skill, 'nivel', 'level')
-        if skill_name and skill_level:
-            template.add_skill_bar(doc, skill_name, skill_level)
 
-# Certificações - procurar por várias possíveis chaves
-certifications_section = None
-for key in ['certificacoes', 'certifications', 'certificaciones', 'certifications']:
-    if key in secoes:
-        certifications_section = secoes[key]
-        break
-
-if certifications_section:
-    template.add_section_title(doc, get_section_title(certifications_section))
-    certifications = get_section_list(certifications_section)
-    
-    for cert in certifications:
-        p = doc.add_paragraph()
-        p.add_run("🏅 ").bold = True
-        p.add_run(cert)
-
-# Educação - procurar por várias possíveis chaves
-education_section = None
-for key in ['educacao', 'education', 'educacion', 'education']:
-    if key in secoes:
-        education_section = secoes[key]
-        break
-
-if education_section:
-    template.add_section_title(doc, get_section_title(education_section))
-    
-    # Obter lista de formações
-    degrees = []
-    for key in ['formacao', 'degrees', 'formacion', 'diplomes']:
-        if key in education_section:
-            degrees = education_section[key]
-            break
-    
-    for degree in degrees:
-        doc.add_paragraph(degree)
-
-# Em Andamento - procurar por várias possíveis chaves
-in_progress_section = None
-for key in ['emAndamento', 'inProgress', 'enProgreso', 'enCours']:
-    if key in secoes:
-        in_progress_section = secoes[key]
-        break
-
-if in_progress_section:
-    template.add_section_title(doc, get_section_title(in_progress_section))
-    
-    # Obter lista de cursos
-    courses = []
-    for key in ['cursos', 'courses', 'cursos', 'cours']:
-        if key in in_progress_section:
-            courses = in_progress_section[key]
-            break
-    
-    for course in courses:
-        doc.add_paragraph(course)
-
-# Nome do arquivo de saída
-output_path = get_field(data, 'nomeArquivoSaida', 'outputFileName')
-if not output_path:
-    # Se nenhum nome de arquivo for especificado, criar um a partir do nome e idioma
-    if nome:
-        output_path = f"Curriculo_{nome.replace(' ', '_')}_{selected_lang}.docx"
-    else:
-        output_path = f"Curriculo_{selected_lang}.docx"
-
-doc.save(output_path)
-
-print(f"Arquivo salvo como: {output_path}")
+if __name__ == "__main__":
+    main()

--- a/curriculo_pdf.py
+++ b/curriculo_pdf.py
@@ -1,384 +1,165 @@
-from reportlab.lib.pagesizes import A4
-from reportlab.lib import colors
-from reportlab.lib.styles import getSampleStyleSheet, ParagraphStyle
-from reportlab.platypus import SimpleDocTemplate, Paragraph, Spacer, ListFlowable, ListItem, Table, TableStyle, PageBreak
-from reportlab.lib.units import inch, cm
-from reportlab.pdfgen import canvas
-from reportlab.pdfbase import pdfmetrics
-from reportlab.pdfbase.ttfonts import TTFont
-import os
-import json
-import sys
-import glob
+"""Generate PDF resumes from JSON data."""
+from __future__ import annotations
+
 import argparse
-from templates import TemplateManager
-from reportlab.pdfbase.ttfonts import TTFont
-import os
 import json
+import os
 import sys
-import glob
+
+from reportlab.platypus import Paragraph, Spacer
+from reportlab.lib.units import inch
 from templates import TemplateManager
+from utils import (
+    get_available_languages,
+    get_field,
+    get_jobs,
+    get_section_content,
+    get_section_list,
+    get_section_title,
+)
 
-# Função genérica para obter valores do JSON de maneira padronizada
-def get_field(data, primary_key, fallback_key=None, additional_fallbacks=None):
-    if primary_key in data:
-        return data[primary_key]
-    elif fallback_key and fallback_key in data:
-        return data[fallback_key]
-    
-    # Verificar chaves adicionais específicas para alguns campos
-    if additional_fallbacks:
-        for key in additional_fallbacks:
-            if key in data:
-                return data[key]
-    
-    return None
 
-# Função genérica para obter título de seção
-def get_section_title(section_data, title_keys=['titulo', 'title', 'titre', 'titel']):
-    for key in title_keys:
-        if key in section_data:
-            return section_data[key]
-    return "N/A"  # Fallback
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Gerar currículo em formato PDF.")
+    parser.add_argument("language", nargs="?", help="Código do idioma (ex: pt, en, es)")
+    parser.add_argument("--template", "-t", default="pdf", help="Nome do template a ser usado")
+    parser.add_argument("--json-file", help="Caminho para um arquivo JSON personalizado", default=None)
+    return parser.parse_args()
 
-# Função genérica para obter conteúdo de seção
-def get_section_content(section_data, content_keys=['conteudo', 'content', 'contenido', 'inhalt']):
-    for key in content_keys:
-        if key in section_data:
-            return section_data[key]
-    return ""  # Fallback
 
-# Função genérica para obter lista de itens
-def get_section_list(section_data, list_keys=['lista', 'list', 'liste', 'lista']):
-    for key in list_keys:
-        if key in section_data:
-            return section_data[key]
-    return []  # Fallback
+def load_resume_data(language: str | None, json_file: str | None) -> tuple[dict, str]:
+    available_languages = get_available_languages()
+    default_lang = "pt" if "pt" in available_languages else next(iter(available_languages), None)
+    selected_lang = default_lang
+    if language and language.lower() in available_languages:
+        selected_lang = language.lower()
 
-# Função genérica para obter lista de empregos/experiências
-def get_jobs(section_data, jobs_keys=['empregos', 'jobs', 'empleos', 'emplois']):
-    for key in jobs_keys:
-        if key in section_data:
-            return section_data[key]
-    return []  # Fallback
-
-# Configurar os argumentos de linha de comando
-parser = argparse.ArgumentParser(description='Gerar currículo em formato PDF.')
-parser.add_argument('language', nargs='?', help='Código do idioma (ex: pt, en, es)')
-parser.add_argument('--template', '-t', help='Nome do template a ser usado', default='pdf')
-parser.add_argument('--json-file', help='Caminho para um arquivo JSON personalizado', default=None)
-args = parser.parse_args()
-
-# Função para listar idiomas disponíveis
-def get_available_languages():
-    # Procurar todos os arquivos JSON que seguem o padrão curriculo_XX.json
-    json_files = glob.glob('curriculo_*.json')
-    languages = {}
-    
-    for file in json_files:
-        # Extrair o código do idioma do nome do arquivo (curriculo_XX.json -> XX)
-        lang_code = file.replace('curriculo_', '').replace('.json', '')
-        
-        # Carregar o arquivo para obter o nome do idioma na própria língua
-        try:
-            with open(file, 'r', encoding='utf-8') as f:
-                data = json.load(f)
-                
-                # Verificar se o arquivo tem a estrutura esperada
-                if 'languageName' in data:
-                    lang_name = data['languageName']
-                else:
-                    # Fallback para casos onde o nome do idioma não está definido
-                    lang_name = lang_code.upper()
-                
-                languages[lang_code] = {
-                    'name': lang_name,
-                    'file': file
-                }
-        except:
-            # Se houver erro ao carregar ou analisar, pular este arquivo
-            pass
-    
-    return languages
-
-# Determinar o idioma a ser usado
-available_languages = get_available_languages()
-
-# Default para português se disponível, caso contrário usa o primeiro idioma disponível
-default_lang = 'pt' if 'pt' in available_languages else list(available_languages.keys())[0] if available_languages else None
-
-# Verificar qual idioma usar com base nos argumentos de linha de comando
-selected_lang = default_lang
-if args.language:
-    lang_arg = args.language.lower()
-    if lang_arg in available_languages:
-        selected_lang = lang_arg
-
-# Se não houver idiomas disponíveis, terminar o programa
-if not selected_lang and not args.json_file:
-    print("Erro: Não foram encontrados arquivos de idioma válidos.")
-    sys.exit(1)
-
-# Carregar o arquivo JSON
-if args.json_file:
-    print(f"Usando arquivo JSON personalizado: {args.json_file}")
-    # Usar o arquivo JSON personalizado
-    try:
-        with open(args.json_file, 'r', encoding='utf-8') as file:
-            data = json.load(file)
-    except Exception as e:
-        print(f"Erro ao carregar arquivo JSON personalizado: {str(e)}")
+    if not selected_lang and not json_file:
+        print("Erro: Não foram encontrados arquivos de idioma válidos.")
         sys.exit(1)
-else:
-    # Carregar o arquivo JSON do idioma selecionado
-    json_file = available_languages[selected_lang]['file']
-    with open(json_file, 'r', encoding='utf-8') as file:
-        data = json.load(file)
 
-# Extrair dados básicos do JSON
-# Estrutura padronizada para todas as línguas
-nome = get_field(data, 'nome', 'name', ['nombre'])
-email = data['email']  # Email geralmente é o mesmo em qualquer idioma
-telefone = get_field(data, 'telefone', 'phone')
-linkedin = data['linkedin']  # LinkedIn geralmente é o mesmo em qualquer idioma
+    if json_file:
+        with open(json_file, "r", encoding="utf-8") as file:
+            data = json.load(file)
+        return data, selected_lang or "pt"
 
-# Determinar qual é a chave principal para seções
-secoes_key = None
-for key in ['secoes', 'sections', 'secciones', 'sektionen']:
-    if key in data:
-        secoes_key = key
-        break
+    json_file_path = available_languages[selected_lang]["file"]
+    with open(json_file_path, "r", encoding="utf-8") as file:
+        return json.load(file), selected_lang
 
-# Se não encontrarmos a chave das seções, não podemos continuar
-if not secoes_key:
-    print("Erro: Formato de arquivo JSON inválido. A chave de seções não foi encontrada.")
-    sys.exit(1)
 
-secoes = data[secoes_key]
+def build_pdf(data: dict, template_name: str, selected_lang: str) -> str:
+    template_manager = TemplateManager()
+    try:
+        template = template_manager.get_template(template_name)
+    except ValueError:
+        print(f"Template '{template_name}' não encontrado. Usando padrão 'pdf'.")
+        template = template_manager.get_template("pdf")
 
-# Carregar o template
-template_manager = TemplateManager()
-template_name = args.template
+    pdf_filename = get_field(data, "nomeArquivoSaida", "outputFileName")
+    nome = get_field(data, "nome", "name", ["nombre"])
+    if not pdf_filename:
+        base = nome.replace(" ", "_") if nome else "Curriculo"
+        pdf_filename = f"{base}_{selected_lang}.pdf"
+    if not pdf_filename.lower().endswith(".pdf"):
+        pdf_filename = os.path.splitext(pdf_filename)[0] + ".pdf"
 
-try:
-    template = template_manager.get_template(template_name)
-    print(f"Usando template: {template_name}")
-except ValueError as e:
-    print(f"Erro ao carregar template: {str(e)}")
-    print(f"Templates disponíveis: {', '.join(template_manager.list_templates())}")
-    print("Usando o template padrão 'pdf'.")
-    template = template_manager.get_template('pdf')
+    doc = template.create_document(pdf_filename)
+    styles = template.get_styles()
+    elements: list = []
 
-# Obter nome do arquivo para saída PDF
-output_filename = get_field(data, 'nomeArquivoSaida', 'outputFileName')
-if not output_filename:    # Se nenhum nome de arquivo for especificado, criar um a partir do nome e idioma
-    if nome:
-        output_filename = f"Curriculo_{nome.replace(' ', '_')}_{selected_lang}.pdf"
-    else:
-        output_filename = f"Curriculo_{selected_lang}.pdf"
+    email = data.get("email", "")
+    telefone = get_field(data, "telefone", "phone")
+    linkedin = data.get("linkedin", "")
 
-# Converter para PDF (substituindo .docx por .pdf se necessário)
-pdf_filename = os.path.splitext(output_filename)[0]
-if not pdf_filename.lower().endswith('.pdf'):
-    pdf_filename += ".pdf"
+    template.add_title(elements, nome, email, telefone, linkedin, styles)
 
-# Criar documento PDF
-doc = template.create_document(pdf_filename)
+    secoes_key = next((k for k in ["secoes", "sections", "secciones", "sektionen"] if k in data), None)
+    if not secoes_key:
+        raise ValueError("Formato de arquivo JSON inválido. A chave de seções não foi encontrada.")
+    secoes = data[secoes_key]
 
-# Obter estilos definidos no template
-styles = template.get_styles()
+    resume_section = next((secoes[k] for k in [
+        "resumoProfissional",
+        "professionalSummary",
+        "resumenProfesional",
+        "resumentProfessionnel",
+    ] if k in secoes), None)
+    if resume_section:
+        template.add_section_title(elements, get_section_title(resume_section), styles)
+        elements.append(Paragraph(get_section_content(resume_section), styles["normal"]))
+        elements.append(Spacer(1, 0.1 * inch))
 
-# Lista para elementos do PDF
-elements = []
+    experience_section = next((secoes[k] for k in [
+        "experienciaProfissional",
+        "workExperience",
+        "experienciaLaboral",
+        "experienceProfessionnelle",
+    ] if k in secoes), None)
+    if experience_section:
+        template.add_section_title(elements, get_section_title(experience_section), styles)
+        for job in get_jobs(experience_section):
+            position = get_field(job, "cargo", "position")
+            if position:
+                elements.append(Paragraph(f"• {position}", styles["bullet"]))
+            period = get_field(job, "periodo", "period")
+            if period:
+                elements.append(Paragraph(period, styles["normal"]))
+            description_content = next((job[k] for k in ["descricao", "description", "descripcion"] if k in job), None)
+            processed = []
+            if isinstance(description_content, str):
+                processed = [s.strip() for s in description_content.split("\n") if s.strip()]
+            elif isinstance(description_content, list):
+                processed = [str(item).strip() for item in description_content if str(item).strip()]
+            for item_text in processed:
+                elements.append(Paragraph(f"- {item_text}", styles["bullet"]))
+            elements.append(Spacer(1, 0.1 * inch))
 
-# Montar o currículo visual
-template.add_title(elements, nome, email, telefone, linkedin, styles)
+    template.add_page_break(elements)
+    skills_section = next((secoes[k] for k in ["habilidadesTecnicas", "technicalSkills", "competencesTechniques"] if k in secoes), None)
+    if skills_section:
+        template.add_section_title(elements, get_section_title(skills_section), styles)
+        skills = next((skills_section[k] for k in ["habilidades", "skills", "competencias", "competences"] if k in skills_section), [])
+        for skill in skills:
+            skill_name = get_field(skill, "name", "nome", ["nombre"])
+            skill_level_str = get_field(skill, "level", "nivel")
+            if skill_name and skill_level_str:
+                try:
+                    template.add_skill_bar(elements, skill_name, styles, int(skill_level_str))
+                except ValueError:
+                    print(f"Aviso: Nível de habilidade inválido para '{skill_name}'. Pulando.")
+        elements.append(Spacer(1, 0.1 * inch))
 
-# Resumo Profissional - procurar por várias possíveis chaves
-resume_section = None
-for key in ['resumoProfissional', 'professionalSummary', 'resumenProfesional', 'resumentProfessionnel']:
-    if key in secoes:
-        resume_section = secoes[key]
-        break
+    certifications_section = next((secoes[k] for k in ["certificacoes", "certifications", "certificaciones", "certifications"] if k in secoes), None)
+    if certifications_section:
+        template.add_section_title(elements, get_section_title(certifications_section), styles)
+        for cert in get_section_list(certifications_section):
+            elements.append(Paragraph(f"🏅 {cert}", styles["normal"]))
+        elements.append(Spacer(1, 0.1 * inch))
 
-if resume_section:
-    template.add_section_title(elements, get_section_title(resume_section), styles)
-    elements.append(Paragraph(get_section_content(resume_section), styles['normal']))
-    elements.append(Spacer(1, 0.1*inch))
+    education_section = next((secoes[k] for k in ["educacao", "education", "educacion", "education"] if k in secoes), None)
+    if education_section:
+        template.add_section_title(elements, get_section_title(education_section), styles)
+        for degree in next((education_section[k] for k in ["formacao", "degrees", "formacion", "diplomes"] if k in education_section), []):
+            elements.append(Paragraph(degree, styles["normal"]))
+        elements.append(Spacer(1, 0.1 * inch))
 
-# Experiência Profissional - procurar por várias possíveis chaves
-experience_section = None
-for key in ['experienciaProfissional', 'workExperience', 'experienciaLaboral', 'experienceProfessionnelle']:
-    if key in secoes:
-        experience_section = secoes[key]
-        break
+    in_progress_section = next((secoes[k] for k in ["emAndamento", "inProgress", "enProgreso", "enCours"] if k in secoes), None)
+    if in_progress_section:
+        template.add_section_title(elements, get_section_title(in_progress_section), styles)
+        for course in next((in_progress_section[k] for k in ["cursos", "courses", "cursos", "cours"] if k in in_progress_section), []):
+            elements.append(Paragraph(course, styles["normal"]))
 
-if experience_section:
-    template.add_section_title(elements, get_section_title(experience_section), styles)
-    
-    # Obter lista de empregos
-    jobs = get_jobs(experience_section)
-    
-    # Adicionar empregos
-    for job in jobs:
-        position = get_field(job, 'cargo', 'position')
-        if position:
-            elements.append(Paragraph(f"• {position}", styles['bullet']))
-        
-        period = get_field(job, 'periodo', 'period')
-        if period:
-            elements.append(Paragraph(period, styles['normal']))
-        
-        # Obter descrição - procurar por várias possíveis chaves
-        description_content = None
-        for key in ['descricao', 'description', 'descripcion']:
-            if key in job:
-                description_content = job[key]
-                break
-        
-        processed_description_items = []
-        if isinstance(description_content, str):
-            # If it's a string, split by newlines to create multiple bullet points.
-            # Filter out empty strings that might result from multiple newlines.
-            processed_description_items = [s.strip() for s in description_content.split('\\n') if s.strip()]
-            # If splitting by newline results in an empty list, but the original string was not empty,
-            # treat the original string as a single item. This covers cases where the string has no newlines.
-            if not processed_description_items and description_content.strip():
-                 processed_description_items = [description_content.strip()]
-        elif isinstance(description_content, list):
-            # If it's already a list, assume each item is a bullet point
-            # Ensure all items are strings and stripped of whitespace.
-            processed_description_items = [str(item).strip() for item in description_content if str(item).strip()]
+    doc.build(elements)
+    return pdf_filename
 
-        # Create Paragraph objects for each processed description item
-        item_paragraphs = []
-        for item_text in processed_description_items:
-            item_paragraphs.append(Paragraph(f"- {item_text}", styles['bullet']))
-            
-        for p in item_paragraphs:
-            elements.append(p)
-        
-        elements.append(Spacer(1, 0.1*inch))
 
-# Habilidades Técnicas - procurar por várias possíveis chaves
-template.add_page_break(elements)
-skills_section = None
-# Ensure unique keys in a preferred order for lookup
-for key in ['habilidadesTecnicas', 'technicalSkills', 'competencesTechniques']: # PT/ES, EN, FR
-    if key in secoes:
-        skills_section = secoes[key]
-        break
+def main() -> None:
+    args = parse_args()
+    data, lang = load_resume_data(args.language, args.json_file)
+    output = build_pdf(data, args.template, lang)
+    print(f"Arquivo PDF salvo como: {output}")
 
-if skills_section:
-    template.add_section_title(elements, get_section_title(skills_section), styles)
-      # Obter lista de habilidades
-    skills = []
-    # Ensure unique keys in a preferred order for lookup
-    for key in ['habilidades', 'skills', 'competencias', 'competences']: # Added 'competencias' for robustness, ensure unique keys
-        if key in skills_section:
-            skills = skills_section[key]
-            break
-    
-    for skill in skills:
-        # Adjusted get_field calls to correctly find keys for different languages
-        skill_name = get_field(skill, 'name', 'nome', ['nombre']) # Checks 'name', then 'nome', then 'nombre'
-        skill_level_str = get_field(skill, 'level', 'nivel') # Checks 'level', then 'nivel'
-        if skill_name and skill_level_str:
-            try:
-                skill_level = int(skill_level_str) # Convert to integer
-                template.add_skill_bar(elements, skill_name, styles, skill_level)
-            except ValueError:
-                print(f"Aviso: Nível de habilidade inválido para '{skill_name}'. Esperado um número, recebido '{skill_level_str}'. Pulando esta habilidade.")
-    
-    elements.append(Spacer(1, 0.1*inch))
 
-# Certificações - procurar por várias possíveis chaves
-certifications_section = None
-for key in ['certificacoes', 'certifications', 'certificaciones', 'certifications']:
-    if key in secoes:
-        certifications_section = secoes[key]
-        break
-
-if certifications_section:
-    template.add_section_title(elements, get_section_title(certifications_section), styles)
-    certifications = get_section_list(certifications_section)
-    
-    for cert in certifications:
-        elements.append(Paragraph(f"🏅 {cert}", styles['normal']))
-    
-    elements.append(Spacer(1, 0.1*inch))
-
-# Educação - procurar por várias possíveis chaves
-education_section = None
-for key in ['educacao', 'education', 'educacion', 'education']:
-    if key in secoes:
-        education_section = secoes[key]
-        break
-
-if education_section:
-    template.add_section_title(elements, get_section_title(education_section), styles)
-    
-    # Obter lista de formações
-    degrees = []
-    for key in ['formacao', 'degrees', 'formacion', 'diplomes']:
-        if key in education_section:
-            degrees = education_section[key]
-            break
-    
-    for degree in degrees:
-        elements.append(Paragraph(degree, styles['normal']))
-    
-    elements.append(Spacer(1, 0.1*inch))
-
-# Em Andamento - procurar por várias possíveis chaves
-in_progress_section = None
-for key in ['emAndamento', 'inProgress', 'enProgreso', 'enCours']:
-    if key in secoes:
-        in_progress_section = secoes[key]
-        break
-
-if in_progress_section:
-    template.add_section_title(elements, get_section_title(in_progress_section), styles)
-    
-    # Obter lista de cursos
-    courses = []
-    for key in ['cursos', 'courses', 'cursos', 'cours']:
-        if key in in_progress_section:
-            courses = in_progress_section[key]
-            break
-    
-    for course in courses:
-        elements.append(Paragraph(course, styles['normal']))
-
-# Gerar o PDF
-try:   
-    if os.path.exists(pdf_filename):
-        try:
-            # Tentar renomear temporariamente o arquivo existente
-            temp_name = pdf_filename + ".old"
-            if os.path.exists(temp_name):
-                os.remove(temp_name)
-            os.rename(pdf_filename, temp_name)
-            
-            # Gerar o novo PDF
-            doc.build(elements)
-            
-            # Se deu certo, remover o arquivo antigo
-            if os.path.exists(temp_name):
-                os.remove(temp_name)
-                
-        except Exception as e:
-            # Se falhar em renomear, tentar outro nome de arquivo
-            alternative_filename = os.path.splitext(pdf_filename)[0] + "_new.pdf"
-            doc = template.create_document(alternative_filename)
-            doc.build(elements)
-            pdf_filename = alternative_filename
-    else:
-        # Se não existir, simplesmente criar o arquivo
-        doc.build(elements)
-        
-    print(f"Arquivo PDF salvo como: {pdf_filename}")
-    
-except Exception as e:
-    print(f"Erro ao gerar o PDF: {str(e)}")
-    print("Tente fechar o arquivo PDF se ele estiver aberto em outro programa.")
+if __name__ == "__main__":
+    main()

--- a/utils.py
+++ b/utils.py
@@ -1,0 +1,64 @@
+"""Utility functions for JSON-based resume generation."""
+import glob
+import json
+import os
+from typing import Any, Dict, Iterable, Optional
+
+
+def get_available_languages(directory: str = '.', pattern: str = 'curriculo_*.json') -> Dict[str, Dict[str, str]]:
+    """Return mapping of language codes to metadata."""
+    json_files = glob.glob(os.path.join(directory, pattern))
+    languages: Dict[str, Dict[str, str]] = {}
+    for file in json_files:
+        lang_code = os.path.basename(file).replace('curriculo_', '').replace('.json', '')
+        try:
+            with open(file, 'r', encoding='utf-8') as f:
+                data = json.load(f)
+            lang_name = data.get('languageName', lang_code.upper())
+            languages[lang_code] = {'name': lang_name, 'file': file}
+        except Exception:
+            # skip malformed files
+            continue
+    return languages
+
+
+def get_field(data: Dict[str, Any], primary_key: str, fallback_key: Optional[str] = None, additional_fallbacks: Optional[Iterable[str]] = None) -> Optional[Any]:
+    """Retrieve a value from a dictionary with optional fallbacks."""
+    if primary_key in data:
+        return data[primary_key]
+    if fallback_key and fallback_key in data:
+        return data[fallback_key]
+    if additional_fallbacks:
+        for key in additional_fallbacks:
+            if key in data:
+                return data[key]
+    return None
+
+
+def get_section_title(section_data: Dict[str, Any], title_keys: Iterable[str] = ('titulo', 'title', 'titre', 'titel')) -> str:
+    for key in title_keys:
+        if key in section_data:
+            return section_data[key]
+    return 'N/A'
+
+
+def get_section_content(section_data: Dict[str, Any], content_keys: Iterable[str] = ('conteudo', 'content', 'contenido', 'inhalt')) -> str:
+    for key in content_keys:
+        if key in section_data:
+            return section_data[key]
+    return ''
+
+
+def get_section_list(section_data: Dict[str, Any], list_keys: Iterable[str] = ('lista', 'list', 'liste', 'lista')) -> list:
+    for key in list_keys:
+        if key in section_data:
+            return section_data[key]
+    return []
+
+
+def get_jobs(section_data: Dict[str, Any], jobs_keys: Iterable[str] = ('empregos', 'jobs', 'empleos', 'emplois')) -> list:
+    for key in jobs_keys:
+        if key in section_data:
+            return section_data[key]
+    return []
+

--- a/wsgi.py
+++ b/wsgi.py
@@ -1,18 +1,16 @@
-import sys
 import os
+import sys
 
 # Configurar variável de ambiente para indicar que estamos em produção
-os.environ['FLASK_ENV'] = 'production'
-os.environ['RENDER'] = 'true'
+os.environ["FLASK_ENV"] = "production"
+os.environ["RENDER"] = "true"
 
-# Adicionar diretório raiz ao path
-sys.path.append(os.path.dirname(os.path.abspath(__file__)))
-# Adicionar diretório web ao path
-sys.path.append(os.path.join(os.path.dirname(os.path.abspath(__file__)), "web"))
+# Adicionar diretório raiz e pasta web ao path
+ROOT_DIR = os.path.dirname(os.path.abspath(__file__))
+sys.path.append(ROOT_DIR)
+sys.path.append(os.path.join(ROOT_DIR, "web"))
 
-# Importar a aplicação Flask
 from web.app import app
 
-# Para execução direta deste arquivo
 if __name__ == "__main__":
-    app.run(host='0.0.0.0', port=int(os.environ.get('PORT', 8080)))
+    app.run(host="0.0.0.0", port=int(os.environ.get("PORT", 8080)))


### PR DESCRIPTION
## Summary
- extract common helper functions to `utils.py`
- refactor `curriculo_docx.py` and `curriculo_pdf.py` to use helpers and wrap logic in `main`
- clean up wsgi script

## Testing
- `python -m py_compile utils.py curriculo_docx.py curriculo_pdf.py wsgi.py`
- `python -m py_compile curriculo_pdf_ats.py cv-generator.py web/app.py`

------
https://chatgpt.com/codex/tasks/task_e_6840a1e4a018832fbad5cb9d1bfb293b